### PR TITLE
uart: fix xonxoff value in mraa_uart_settings()

### DIFF
--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -419,7 +419,7 @@ mraa_uart_settings(int index, const char **devpath, const char **name, int* baud
        }
 
        if (xonxoff != NULL) {
-           *xonxoff = term.c_cflag & (IXON|IXOFF);
+           *xonxoff = term.c_iflag & (IXON|IXOFF);
        }
 
        close(fd);


### PR DESCRIPTION
the value of xonxoff(IXON|IXOFF) resides in the c_iflag field in
struct termios, not c_cflag.

Signed-off-by: Benxi Liu <bxliu@linux.alibaba.com>